### PR TITLE
Update SparkPostTransport.php

### DIFF
--- a/src/Mailer/Transport/SparkPostTransport.php
+++ b/src/Mailer/Transport/SparkPostTransport.php
@@ -63,7 +63,7 @@ class SparkPostTransport extends AbstractTransport
             'from' => $sender,
             'html' => empty($email->message('html')) ? $email->message('text') : $email->message('html'),
             'text' => $email->message('text'),
-            'subject' => $email->subject(),
+            'subject' => mb_decode_mimeheader($email->subject()),
             'recipients' => $recipients
         ];
 


### PR DESCRIPTION
SparkPost don't like RFC 2047 encoding for the subject (https://developers.sparkpost.com/api/transmissions)
Causes problems with german umlauts f.e.